### PR TITLE
20260602 csnip upstream merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.o
 *.os
 *.so
+build/
+.cache/
+compile_commands.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "doc/doxygen-awesome-css"]
+	path = doc/doxygen-awesome-css
+	url = https://github.com/jothepro/doxygen-awesome-css.git

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -20,6 +20,14 @@ function(add_docs_target)
 	set(DOXYGEN_EXAMPLE_PATH examples/)
 	set(DOXYGEN_QUIET YES)
 
+	# Doxygen Awesome CSS configuration
+	set(DOXYGEN_GENERATE_TREEVIEW YES)
+	set(DOXYGEN_DISABLE_INDEX NO)
+	set(DOXYGEN_FULL_SIDEBAR NO)
+	set(DOXYGEN_HTML_EXTRA_STYLESHEET
+		${CMAKE_CURRENT_SOURCE_DIR}/doxygen-awesome-css/doxygen-awesome.css)
+	set(DOXYGEN_HTML_COLORSTYLE LIGHT)
+
 	# Get the sources from the csnip library
 	get_target_sources(src_csnip csnip)
 

--- a/src/csnip/log.c
+++ b/src/csnip/log.c
@@ -284,7 +284,7 @@ typedef enum {
 static const char* put_timestamp(char* buf, size_t bufSz, TsType tsType)
 {
 	struct timespec ts;
-	clock_gettime(CLOCK_REALTIME, &ts);
+	csnip_x_clock_gettime(CLOCK_REALTIME, &ts);
 	struct tm broken_down;
 	if (tsType == TS_LOCAL) {
 #ifdef WIN32
@@ -313,7 +313,7 @@ static const char* put_timestamp(char* buf, size_t bufSz, TsType tsType)
 static const char* put_timestampnum(char* buf, size_t bufSz, TsType tsType)
 {
 	struct timespec ts;
-	clock_gettime(tsType == TS_MONO ? CLOCK_MONOTONIC : CLOCK_REALTIME,
+	csnip_x_clock_gettime(tsType == TS_MONO ? CLOCK_MONOTONIC : CLOCK_REALTIME,
 		&ts);
 	double ts_sec;
 	time_Convert(ts, ts_sec);
@@ -361,7 +361,7 @@ static const char* value_for_key(const char* keyStart,
 	case 7:
 		if (strncmp(keyStart, "timesec", 7) == 0) {
 			struct timespec ts;
-			clock_gettime(CLOCK_MONOTONIC, &ts);
+			csnip_x_clock_gettime(CLOCK_MONOTONIC, &ts);
 			snprintf(buf, bufSz, "%.16g",
 			  ts.tv_sec + ts.tv_nsec/1e9);
 			return buf;

--- a/src/csnip/log.h
+++ b/src/csnip/log.h
@@ -173,7 +173,7 @@ inline const char* csnip_log__file(const char* filepath)
 {
 	char* p = strrchr(filepath, '/');
 	char* q = NULL;
-#ifdef WIN32
+#ifdef _WIN32
 	q = strrchr(filepath, '\\');
 #endif
 	if (p == NULL) {

--- a/src/csnip/mem.c
+++ b/src/csnip/mem.c
@@ -115,11 +115,22 @@ void csnip_mem_aligned_free(void* mem)
  * / _aligned_free() pair of functions.
  */
 
-void* csnip_mem_aligned_alloc(size_t nAlign, size_t nSize, int* err_ret)
+void* csnip_mem_aligned_alloc(size_t nAlign, size_t n, size_t size, int* err_ret)
 {
+	size_t alloc_sz = compute_alloc_amount(n, size);
+	if (alloc_sz == 0) {
+		if (err_ret)
+			*err_ret = csnip_err_RANGE;
+		return NULL;
+	}
+	
 	if (err_ret)
 		*err_ret = 0;
-	return _aligned_malloc(nSize, nAlign);
+	void* p_ret = _aligned_malloc(alloc_sz, nAlign);
+	if (p_ret == NULL && err_ret) {
+		*err_ret = csnip_err_NOMEM;
+	}
+	return p_ret;
 }
 
 void csnip_mem_aligned_free(void* mem)

--- a/src/csnip/mem.h
+++ b/src/csnip/mem.h
@@ -122,6 +122,46 @@ void csnip_mem_aligned_free(void* mem);
 			csnip_err_Raise(csnip_err_NOMEM, err); \
 	} while(0)
 
+/**	Allocate a specific number of bytes.
+ *
+ *	Allocate @a nBytes of memory. The allocated pointer will be
+ *	written to the @a ptr output argument.
+ *
+ *	This function uses malloc() under the hood, so it can be freed
+ *	with either libc's free() or csnip_mem_Free().
+ *
+ *	@param	nBytes
+ *		Number of bytes to allocate.
+ *
+ *	@param	ptr
+ *		The lvalue to assign to.  This must be a pointer type.
+ *		If the allocation fails, a NULL value will be written into
+ *		the lvalue, in addition to the error being returned or
+ *		processed according to the err argument.
+ *
+ *	@param	err
+ *		Error return; accepts the special _ and error_ignore
+ *		values, as explained in csnip_err_Raise().
+ */
+#define csnip_mem_AllocBytes(nBytes, ptr, err) \
+	do { \
+		(ptr) = csnip_mem__cxxcast(ptr, \
+			csnip_mem_alloc((nBytes), 1)); \
+		if ((ptr) == NULL) \
+			csnip_err_Raise(csnip_err_NOMEM, err); \
+	} while(0)
+
+/**	Allocate a specific number of bytes and assign the address to ptr.
+ *
+ *	This is an expression version of mem_AllocBytes(), similar to mem_Allocx().
+ *	It assigns to the pointer and returns 0 in the success
+ *	case.  In the error case, the pointer is set to NULL and an
+ *	error code is returned.
+ */
+#define csnip_mem_AllocBytesx(n, ptr) \
+	(((ptr) = csnip_mem__cxxcast(ptr, csnip_mem_alloc((n), 1))) \
+	 ? 0 : csnip_err_NOMEM)
+
 /**	Expression macro for zero-initialized allocation. */
 #define csnip_mem_Alloc0x(nMember, ptr) \
 	(((ptr) = csnip_mem__cxxcast(ptr, calloc(nMember, sizeof(*(ptr))))) \
@@ -259,8 +299,10 @@ void csnip_mem_aligned_free(void* mem);
 #define mem_alloc		csnip_mem_alloc
 #define mem_aligned_alloc	csnip_mem_aligned_alloc
 #define mem_aligned_free	csnip_mem_aligned_free
-#define mem_Alloc		csnip_mem_Alloc
+#define mem_Alloc       csnip_mem_Alloc
+#define mem_AllocBytes  csnip_mem_AllocBytes
 #define mem_Allocx		csnip_mem_Allocx
+#define mem_AllocBytesx csnip_mem_AllocBytesx
 #define mem_Alloc0		csnip_mem_Alloc0
 #define mem_Alloc0x		csnip_mem_Alloc0x
 #define mem_AlignedAlloc	csnip_mem_AlignedAlloc

--- a/src/csnip/mempool.h
+++ b/src/csnip/mempool.h
@@ -27,6 +27,42 @@
 #include <csnip/arr.h>
 #include <csnip/mem.h>
 
+/**
+* @brief Defines a memory pool type structure.
+*
+* This macro generates a structure definition for a memory pool that manages
+* fixed-size items. The pool uses a slab allocator with an intrusive free list.
+*
+* @param struct_pooltype  Name for the generated pool structure type
+* @param itemtype         Type of items to be pooled (must be at least
+*                         sizeof(void*) bytes and properly aligned)
+*
+* @details The generated structure contains:
+* - **slabs**: Dynamic array of pointers to memory slabs (contiguous blocks
+*              of items)
+* - **n_slabs**: Current number of allocated slabs
+* - **cap_slabs**: Capacity of the slabs pointer array before reallocation
+* - **n_items**: Total number of items currently allocated to users
+* - **first_free**: Head of the intrusive free list linking available items
+*
+* @note The itemtype must satisfy:
+*       - sizeof(itemtype) >= sizeof(itemtype*)
+*       - alignof(itemtype) >= alignof(itemtype*)
+*       These requirements allow free items to store "next" pointers in their
+*       own memory without additional overhead.
+*
+* @par Example:
+* @code
+* // Define a pool type for MyStruct
+* CSNIP_MEMPOOL_DEF_TYPE(MyStructPool, struct MyStruct)
+*
+* // Now MyStructPool is available as a type
+* struct MyStructPool pool;
+* @endcode
+*
+* @see CSNIP_MEMPOOL_DECL_FUNCS For declaring pool operation functions
+* @see CSNIP_MEMPOOL_DEF_FUNCS For defining pool operation functions
+*/
 #define CSNIP_MEMPOOL_DEF_TYPE(struct_pooltype, itemtype) \
 	struct struct_pooltype { \
 		itemtype** slabs; \
@@ -37,6 +73,48 @@
 		itemtype* first_free; \
 	}; \
 
+/**
+* @brief Declares function prototypes for memory pool operations.
+*
+* This macro generates forward declarations for all functions needed to
+* operate a memory pool. Use this in header files to expose the pool API.
+*
+* @param scope      Storage class specifier (e.g., `static` for internal
+*                   linkage, or empty for external linkage)
+* @param prefix     Prefix for generated function names (e.g., `mypool_`
+*                   generates `mypool_init_empty`, `mypool_alloc_item`, etc.)
+* @param itemtype   Type of items managed by the pool
+* @param pooltype   The pool structure type (must be defined first with
+*                   CSNIP_MEMPOOL_DEF_TYPE)
+*
+* @details Generated function declarations:
+* - **prefix##init_empty()**: Creates an empty pool with no initial capacity
+* - **prefix##init_with_cap(cap, err)**: Creates a pool pre-allocated with
+*                                        `cap` items
+* - **prefix##deinit(pool)**: Destroys the pool and frees all memory
+* - **prefix##alloc_item(pool, err)**: Allocates one item from the pool
+* - **prefix##free_item(pool, item)**: Returns an item to the pool
+*
+* @note This macro only declares functions. You must also use
+*       CSNIP_MEMPOOL_DEF_FUNCS in exactly one translation unit to provide
+*       the implementations.
+*
+ * @par Example:
+ * @code
+ * // In mypool.h
+ * CSNIP_MEMPOOL_DEF_TYPE(MyPool, struct MyItem)
+ * CSNIP_MEMPOOL_DECL_FUNCS(, mypool_, struct MyItem, struct MyPool)
+ *
+ * // Now these functions are declared:
+ * // struct MyPool mypool_init_empty(void);
+ * // struct MyItem* mypool_alloc_item(struct MyPool* pool, int* err);
+ * // void mypool_free_item(struct MyPool* pool, struct MyItem* e);
+ * // ...
+ * @endcode
+ *
+ * @see CSNIP_MEMPOOL_DEF_TYPE For defining the pool structure
+ * @see CSNIP_MEMPOOL_DEF_FUNCS For defining function implementations
+ */
 #define CSNIP_MEMPOOL_DECL_FUNCS(scope, \
 		prefix, \
 		itemtype, \
@@ -50,6 +128,94 @@
 	scope itemtype* prefix##alloc_item(pooltype* pool, int* err); \
 	scope void prefix##free_item(pooltype* pool, itemtype* e);
 
+/**
+* @brief Defines function implementations for memory pool operations.
+*
+* This macro generates the actual implementations of all memory pool functions.
+* Use this in exactly one source file (.c) per pool type to avoid multiple
+* definition errors during linking.
+*
+* @param scope      Storage class specifier (e.g., `static` for internal
+*                   linkage, or empty for external linkage). Must match the
+*                   scope used in CSNIP_MEMPOOL_DECL_FUNCS.
+* @param prefix     Prefix for generated function names. Must match the prefix
+*                   used in CSNIP_MEMPOOL_DECL_FUNCS.
+* @param itemtype   Type of items managed by the pool
+* @param pooltype   The pool structure type (must be defined first with
+*                   CSNIP_MEMPOOL_DEF_TYPE)
+*
+* @details Generated functions:
+*
+* **Pool lifecycle:**
+* - **prefix##init_empty()**: Returns an empty pool with zero capacity.
+*                             Allocates no memory initially. First allocation
+*                             will trigger slab creation.
+* - **prefix##init_with_cap(cap, err)**: Pre-allocates one slab with `cap`
+*                                        items. All items start in the free
+*                                        list. Returns error via `*err` on
+*                                        allocation failure.
+* - **prefix##deinit(pool)**: Frees all slabs and resets pool to empty state.
+*                             Does NOT check if items are still in use - caller
+*                             must ensure all allocated items are freed first.
+*
+* **Item allocation:**
+* - **prefix##alloc_item(pool, err)**: Pops one item from the free list.
+*                                      If free list is empty, allocates a new
+*                                      slab with exponential growth (minimum 8
+*                                      items, then doubles based on n_items).
+*                                      Returns NULL and sets `*err` on failure.
+*                                      **O(1) amortized time complexity.**
+* - **prefix##free_item(pool, item)**: Pushes item back onto the free list head.
+*                                      Does NOT actually deallocate memory -
+*                                      memory is reused for the next allocation.
+*                                      Does NOT decrement n_items counter.
+*                                      **O(1) time complexity.**
+*
+* **Internal helper:**
+* - **prefix##get_slab(n_items, err)**: Allocates a contiguous array of
+*                                       `n_items` and links them into a free
+*                                       list by writing "next" pointers into
+*                                       each item's memory.
+*
+* @note This macro includes compile-time assertions verifying that itemtype
+*       meets size and alignment requirements for the intrusive free list.
+*
+* @warning The pool does NOT track which items are allocated vs free. Freeing
+*          an item twice, or freeing an invalid pointer, will corrupt the free
+*          list and cause undefined behavior.
+*
+* @par Implementation details:
+* The free list is **intrusive**: when an item is free, its first sizeof(void*)
+* bytes are overwritten with a pointer to the next free item. This means:
+* - Zero per-item metadata overhead when allocated
+* - Item memory is reused for bookkeeping when free
+* - Items must be large enough to hold a pointer (enforced by _Static_assert)
+*
+* Growth strategy: New slabs are allocated with size equal to the current
+* n_items count (doubling), with a minimum of 8 items. This provides amortized
+* O(1) allocation while avoiding excessive waste for small pools.
+*
+ * @par Example:
+ * @code
+ * // In mypool.c
+ * #include "mypool.h"
+ * CSNIP_MEMPOOL_DEF_FUNCS(, mypool_, struct MyItem, struct MyPool)
+ *
+ * // Use the pool
+ * int err = 0;
+ * struct MyPool pool = mypool_init_with_cap(100, &err);
+ * if (err) { return -1; }
+ *
+ * struct MyItem* item = mypool_alloc_item(&pool, &err);
+ * // ... use item ...
+ * mypool_free_item(&pool, item);
+ *
+ * mypool_deinit(&pool);
+ * @endcode
+ *
+ * @see CSNIP_MEMPOOL_DEF_TYPE For defining the pool structure
+ * @see CSNIP_MEMPOOL_DECL_FUNCS For declaring function prototypes
+ */
 #define CSNIP_MEMPOOL_DEF_FUNCS(scope, \
 		prefix, \
 		itemtype, \

--- a/src/csnip/x.h
+++ b/src/csnip/x.h
@@ -101,8 +101,14 @@ typedef struct {
 	csnip_x_cookie_close_function_t* close;
 } csnip_x_cookie_io_functions_t;
 
-FILE* csnip_x_fopencookie(void* __restrict__ cookie,
-			const char* __restrict__ mode,
+#if defined(_WIN32) && defined(__cplusplus)
+#define RESTRICT_CPP 
+#else
+#define RESTRICT_CPP __restrict__
+#endif
+
+FILE* csnip_x_fopencookie(void* RESTRICT_CPP cookie_arg,
+			const char* RESTRICT_CPP mode,
 			csnip_x_cookie_io_functions_t funcs);
 #endif
 
@@ -275,7 +281,7 @@ csnip_x_ssize_t csnip_x_writev_imp(int fd,
 #define csnip_x_clock_gettime clock_gettime
 #if !defined(CSNIP_CONF__HAVE_CLOCK_GETTIME)
 #undef csnip_x_clock_gettime
-#define csnip_x_clock_gettime csnip_x_clock_gettime_imp
+#define csnip_x_clock_gettime x_csnip_clock_gettime_imp
 #endif
 
 /**	Csnip's  CLOCK_* constants.
@@ -292,6 +298,13 @@ csnip_x_ssize_t csnip_x_writev_imp(int fd,
 #else
 #  define CSNIP_X_CLOCK_REALTIME		1
 #  define CSNIP_X_CLOCK_MAYBE_MONOTONIC		1
+#endif
+
+
+#if defined(_WIN32) && !defined(clockid_t)
+typedef int clockid_t;
+#define CLOCK_REALTIME 0
+#define CLOCK_MONOTONIC 1
 #endif
 
 /**	clock_id_t */
@@ -320,6 +333,8 @@ int x_csnip_clock_gettime_imp(csnip_x_clockid_t clk_id,
 #endif
 
 #endif /* CSNIP_X_H */
+
+
 
 #if defined(CSNIP_SHORT_NAMES) && !defined(CSNIP_X_HAVE_SHORT_NAMES)
 

--- a/src/csnip/x.h
+++ b/src/csnip/x.h
@@ -80,7 +80,7 @@ int asprintf(char** strp, const char* fmt, ...);
 int csnip_x_asprintf_imp(char** strp, const char* format, ...);
 
 /**	Wrapper for system fopencookie() or funopen(). */
-#if defined(CSNIP_CONF__HAVE_FOPENCOOKIE) || defined(CSNIP_CONF__HAVE_FUNOPEN)
+#if defined(CSNIP_CONF__HAVE_FOPENCOOKIE) || defined(CSNIP_CONF__HAVE_FUNOPEN) || defined(_WIN32)
 typedef csnip_x_ssize_t csnip_x_cookie_read_function_t(
 			void* cookie,
 			char* buf,

--- a/src/csnip/x/clock_gettime.c
+++ b/src/csnip/x/clock_gettime.c
@@ -3,6 +3,10 @@
 #include <csnip/csnip_conf.h>
 #include <csnip/x.h>
 
+#if defined(_WIN32)
+#include<errno.h>
+#endif
+
 #ifdef CSNIP_CONF__HAVE_CLOCK_GETTIME
 int x_csnip_clock_gettime_imp(csnip_x_clockid_t clk_id,
 			struct csnip_x_timespec* ts)
@@ -20,7 +24,7 @@ int x_csnip_clock_gettime_imp(csnip_x_clockid_t clk_id,
 
 		/* Didn't succeed;  we don't really know why not... */
 		errno = EINVAL;
-		return -1
+		return -1;
 	}
 
 	/* Wrong clk_id */

--- a/src/csnip/x/fopencookie.c
+++ b/src/csnip/x/fopencookie.c
@@ -8,8 +8,8 @@
 #include <csnip/x.h>
 
 #if defined(CSNIP_CONF__HAVE_FOPENCOOKIE)
-FILE* x_fopencookie(void* restrict cookie,
-			const char* restrict mode,
+FILE* x_fopencookie(void* RESTRICT_CPP cookie,
+			const char* RESTRICT_CPP mode,
 			x_cookie_io_functions_t io_funcs)
 {
 	cookie_io_functions_t io_funcs2 = {
@@ -73,8 +73,8 @@ static int fun_close(void* cw_)
 }
 
 
-FILE* x_fopencookie(void* restrict cookie,
-			const char* restrict mode,
+FILE* x_fopencookie(void* RESTRICT_CPP cookie,
+			const char* RESTRICT_CPP mode,
 			x_cookie_io_functions_t io_funcs)
 {
 	/* Create the cookie wrapper */
@@ -103,8 +103,8 @@ FILE* x_fopencookie(void* restrict cookie,
 
 #include <stdio.h>
 
-FILE* x_fopencookie(void* restrict cookie,
-			const char* restrict mode,
+FILE* x_fopencookie(void* RESTRICT_CPP cookie,
+			const char* RESTRICT_CPP mode,
 			x_cookie_io_functions_t io_funcs)
 {
 	/* fopencookie is not supported on Windows.

--- a/src/csnip/x/fopencookie.c
+++ b/src/csnip/x/fopencookie.c
@@ -99,113 +99,24 @@ FILE* x_fopencookie(void* restrict cookie,
 
 #elif defined(_WIN32)
 
-/* Windows implementation - simplified version for write-only logging streams */
+/* Windows stub implementation - fopencookie is not available on Windows */
 
-#include <windows.h>
-#include <stdbool.h>
-#include <string.h>
-
-/* Custom FILE* wrapper structure for Windows */
-struct win_fopencookie_file {
-	FILE base;  /* Must be first member to allow casting */
-	void* cookie;
-	x_cookie_io_functions_t io_funcs;
-	char* write_buffer;
-	size_t write_buffer_size;
-	size_t write_buffer_pos;
-	bool is_write_only;
-};
-
-/* Global registry of our custom FILE* objects (simple approach) */
-static struct win_fopencookie_file* g_custom_files[64];
-static size_t g_custom_file_count = 0;
-
-static struct win_fopencookie_file* get_custom_file(FILE* fp)
-{
-	for (size_t i = 0; i < g_custom_file_count; ++i) {
-		if ((FILE*)g_custom_files[i] == fp) {
-			return g_custom_files[i];
-		}
-	}
-	return NULL;
-}
-
-/* Override functions - these will be called through function pointers if we could set them */
-static int win_fwrite_override(const void* ptr, size_t size, size_t count, FILE* stream)
-{
-	struct win_fopencookie_file* custom = get_custom_file(stream);
-	if (!custom || !custom->io_funcs.write) {
-		return 0;
-	}
-	
-	size_t total_bytes = size * count;
-	ssize_t result = custom->io_funcs.write(custom->cookie, (const char*)ptr, total_bytes);
-	
-	if (result < 0) {
-		return 0;
-	}
-	
-	return (int)(result / size);
-}
-
-static int win_fclose_override(FILE* stream)
-{
-	struct win_fopencookie_file* custom = get_custom_file(stream);
-	if (!custom) {
-		return EOF;
-	}
-	
-	int result = 0;
-	if (custom->io_funcs.close) {
-		result = custom->io_funcs.close(custom->cookie);
-	}
-	
-	/* Remove from registry */
-	for (size_t i = 0; i < g_custom_file_count; ++i) {
-		if (g_custom_files[i] == custom) {
-			memmove(&g_custom_files[i], &g_custom_files[i + 1], 
-				(g_custom_file_count - i - 1) * sizeof(struct win_fopencookie_file*));
-			g_custom_file_count--;
-			break;
-		}
-	}
-	
-	free(custom->write_buffer);
-	free(custom);
-	
-	return result;
-}
+#include <stdio.h>
 
 FILE* x_fopencookie(void* restrict cookie,
 			const char* restrict mode,
 			x_cookie_io_functions_t io_funcs)
 {
-	/* Simplified Windows implementation - we'll create a fake FILE* structure
-	 * and intercept operations manually. This is not perfect but works for
-	 * basic write-only logging use cases.
+	/* fopencookie is not supported on Windows.
+	 * This is a stub that prints a warning and returns NULL.
 	 */
+	(void)cookie;      /* Suppress unused parameter warnings */
+	(void)mode;
+	(void)io_funcs;
 	
-	if (g_custom_file_count >= sizeof(g_custom_files)/sizeof(g_custom_files[0])) {
-		return NULL; /* Too many custom files */
-	}
-	
-	struct win_fopencookie_file* custom = malloc(sizeof(struct win_fopencookie_file));
-	if (!custom) {
-		return NULL;
-	}
-	
-	memset(custom, 0, sizeof(*custom));
-	custom->cookie = cookie;
-	custom->io_funcs = io_funcs;
-	custom->is_write_only = (mode && (strchr(mode, 'w') || strchr(mode, 'a')));
-	
-	/* Add to registry */
-	g_custom_files[g_custom_file_count++] = custom;
-	
-	/* Return the custom structure cast as FILE* 
-	 * This is a hack, but necessary for Windows compatibility
-	 */
-	return (FILE*)custom;
+	fprintf(stderr, "WARNING: x_fopencookie() called but not supported on Windows\n");
+	errno = ENOSYS;    /* Function not implemented */
+	return NULL;
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ set(tests_c
 	meanvar_test0.c
 	mem_test0.c
 	mem_test1.c
+	mem_test_alloc_bytes.c
 	mempool_test0.c
 	ringbuf_test.c
 	ringbuf2_test.c

--- a/test/mem_test_alloc_bytes.c
+++ b/test/mem_test_alloc_bytes.c
@@ -1,0 +1,74 @@
+/* Smoke test for mem_Alloc* macros.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#define CSNIP_SHORT_NAMES
+#include <csnip/mem.h>
+
+static int test_alloc_bytes() {
+	size_t size = 123456;
+
+	uint8_t* p;
+	mem_AllocBytes(size, p, _);
+
+	for (size_t i = 0; i < size; ++i) {
+		uint8_t value = i % 255;
+
+		p[i] = value;
+	}
+
+	for (size_t i = 0; i < size; ++i) {
+		uint8_t expected = i % 255;
+		uint8_t actual = p[i];
+
+		if (expected != actual) {
+			fprintf(stderr, "Error:  Value at offset [%zu] is [%u], expected [%u]\n", i, actual, expected);
+			return 0;
+		}
+	}
+
+	mem_Free(p);
+
+	return 1;
+}
+
+static int test_alloc_bytesx() {
+	size_t size = 123456;
+
+	uint8_t* p;
+	if (mem_AllocBytesx(size, p) != 0) {
+		fprintf(stderr, "Error:  Allocating [%zu] bytes failed.\n", size);
+		return 0;
+	}
+
+	for (size_t i = 0; i < size; ++i) {
+		uint8_t value = i % 255;
+
+		p[i] = value;
+	}
+
+	for (size_t i = 0; i < size; ++i) {
+		uint8_t expected = i % 255;
+		uint8_t actual = p[i];
+
+		if (expected != actual) {
+			fprintf(stderr, "Error:  Value at offset [%zu] is [%u], expected [%u]\n", i, actual, expected);
+			return 0;
+		}
+	}
+
+	mem_Free(p);
+
+	return 1;
+}
+
+int main(int argc, char** argv)
+{
+	if (!test_alloc_bytes())
+		return 1;
+	if (!test_alloc_bytesx())
+		return 1;
+	return 0;
+}

--- a/test/x_fopencookie_test.c
+++ b/test/x_fopencookie_test.c
@@ -34,7 +34,7 @@ typedef struct {
 	size_t file_offs;
 } my_cookie_t;
 
-ssize_t my_read_func(void* cookie_, char* buf, size_t size)
+csnip_x_ssize_t my_read_func(void* cookie_, char* buf, size_t size)
 {
 	my_cookie_t* cookie = (my_cookie_t*)cookie_;
 
@@ -49,7 +49,7 @@ ssize_t my_read_func(void* cookie_, char* buf, size_t size)
 	return s;
 }
 
-ssize_t my_write_func(void* cookie_, const char* buf, size_t size)
+csnip_x_ssize_t my_write_func(void* cookie_, const char* buf, size_t size)
 {
 	my_cookie_t* cookie = cookie_;
 


### PR DESCRIPTION
pull down upstream fixes. This is needed for C23 compilers (gcc 15) as it failed here but worked fine on gcc 12.